### PR TITLE
Proof of Concept for sorting of playlists

### DIFF
--- a/resources/functions/load.js
+++ b/resources/functions/load.js
@@ -39,8 +39,18 @@ module.exports = {
             if (!error) {
                 try {
                     let formattedData = data.replace(/\s{2,10}/g, ' ').trim();
+
+                    /*
+                    stop electron from cloning the results (causes errors)
+                    (https://github.com/electron/electron/issues/23722)
+                    the result doesn't get used anyway
+                     */
+                    formattedData += ';0'
+
                     app.win.webContents.executeJavaScript(formattedData).then(() => {
                         console.verbose(`[LoadJSFile] '${path}' successfully injected.`)
+                    }).catch(reason => {
+                        console.log(`[LoadJSFile] Error while injecting: ${path} - ${reason}`)
                     });
                 } catch (err) {
                     console.error(`[LoadJSFile] Error while injecting: ${path} - Error: ${err}`)

--- a/resources/js/addSort.js
+++ b/resources/js/addSort.js
@@ -73,7 +73,7 @@ try {
 
             /* click does not register if we add the event listener to the child divs themselves */
             contentNode.addEventListener('click', event => {
-                let currenSortType = sortConfig.type;
+                let currenSortType = sortConfig.attributeName;
 
                 if (checkClickArea('songs-list__header-col--song', event)) {
                     sortConfig.attributeName = 'name';
@@ -85,7 +85,7 @@ try {
                     sortConfig.attributeName = 'durationInMillis';
                 }
 
-                if (currenSortType === sortConfig.type) {
+                if (currenSortType === sortConfig.attributeName) {
                     sortConfig.order += 1;
 
                     if (sortConfig.order === 3) {

--- a/resources/js/addSort.js
+++ b/resources/js/addSort.js
@@ -1,9 +1,4 @@
 try {
-    /*
-    the queue does not respect the sorting
-        can be done by managing 'MusicKit.getInstance().queue.items'
-    */
-
     let url = window.location.href;
 
     /* check for https://music.apple.com/library/playlist/ (and the beta variant + language code) */
@@ -21,6 +16,8 @@ try {
 
     let fixToAllowSort = [];
     let isSortAllowed = false;
+
+    let doesQueueNeedSorting = false;
 
     /* check if playlist id is set */
     if (matcher && matcher.length === 6 && matcher[4]) {
@@ -42,9 +39,7 @@ try {
 
             /* click does not register if we add the event listener to the child divs themselves */
             contentNode.addEventListener('click', event => {
-                if (!isSortAllowed) {
-                    return;
-                }
+                let currenSortType = lastSortType;
 
                 if (checkClickArea('songs-list__header-col--song', event)) {
                     lastSortType = 'song';
@@ -54,6 +49,10 @@ try {
                     lastSortType = 'album';
                 } else if (checkClickArea('songs-list__header-col--time', event)) {
                     lastSortType = 'time';
+                }
+
+                if (currenSortType !== lastSortType) {
+                    doesQueueNeedSorting = true;
                 }
 
                 handleSort();
@@ -172,6 +171,10 @@ try {
     }
 
     function handleSort() {
+        if (!isSortAllowed) {
+            return;
+        }
+
         if (lastSortType) {
             switch (lastSortType) {
                 case 'song':
@@ -186,7 +189,8 @@ try {
                     break;
             }
 
-            manageNodes();
+            sortNodes();
+            sortQueue();
 
             console.log('[JS] [addSort] Sorted Stored Songs:', songs);
         }
@@ -214,6 +218,31 @@ try {
         songNodes.set(id, node);
     }
 
+    function sortQueue() {
+        /* todo
+        let queueItems = MusicKit.getInstance().queue.items;
+
+        if (queueItems.length > 0) {
+            console.log(queueItems);
+
+        }
+        */
+
+        /*
+        current queue behaviour (decided by apple) when you click 'play' on a song in the playlist:
+            1. clears the queue
+            2. fills the queue with all songs that are ordered after the one you clicked on
+
+        what needs to be done:
+            1. decide wether we sort the queue or not
+                i. e. is the user just sorting the ui elements
+                even if the user plays a song on the sorted playlist, he might not want the queue to be sorted?
+            2. listen to queue or playback changes (= user clicks play on a song in the playlist)
+                depending on what we listen we will need a variable that keeps in mind if the queue was sorted with the latest sort option
+            2. loop through the queue elements and sort them according to the stored songs
+        */
+    }
+
     function handleSongsMissingNodes() {
         for (let song of songs.values()) {
             if (!song.node) {
@@ -222,7 +251,7 @@ try {
         }
     }
 
-    function manageNodes() {
+    function sortNodes() {
         observer.disconnect();
 
         let headerNode = contentNode.getElementsByClassName('songs-list__header')[0];

--- a/resources/js/addSort.js
+++ b/resources/js/addSort.js
@@ -111,7 +111,7 @@ try {
 
         /* add the node elements to the song data */
         for (let song of songs.values()) {
-            for (data of songNodeData) {
+            for (let data of songNodeData) {
                 if (data.songName === song.data.attributes.name && data.albumName === song.data.attributes.albumName) {
                     song.node = data.node;
                 }

--- a/resources/js/addSort.js
+++ b/resources/js/addSort.js
@@ -73,7 +73,7 @@ try {
 
             /* click does not register if we add the event listener to the child divs themselves */
             contentNode.addEventListener('click', event => {
-                let currenSortType = sortConfig.attributeName;
+                let previousAttributeName = sortConfig.attributeName;
 
                 if (checkClickArea('songs-list__header-col--song', event)) {
                     sortConfig.attributeName = 'name';
@@ -85,7 +85,7 @@ try {
                     sortConfig.attributeName = 'durationInMillis';
                 }
 
-                if (currenSortType === sortConfig.attributeName) {
+                if (previousAttributeName === sortConfig.attributeName) {
                     sortConfig.order += 1;
 
                     if (sortConfig.order === 3) {
@@ -192,6 +192,11 @@ try {
     }
 
     function handleSort() {
+        if (!sortConfig.attributeName) {
+            /* do nothing if no sort has been applied yet */
+            return;
+        }
+
         let startTime = performance.now();
 
         sortSongs();
@@ -355,7 +360,11 @@ try {
             });
 
             handleSongsMissingNodes();
-            handleSort();
+
+            /* there is no sorting required if the order is the original layout */
+            if (sortConfig.order !== 0) {
+                handleSort();
+            }
         });
     }
 } catch (e) {

--- a/resources/js/addSort.js
+++ b/resources/js/addSort.js
@@ -1,0 +1,186 @@
+try {
+    /*
+    the queue does not respect the sorting
+        can be done by managing 'MusicKit.getInstance().queue.items'
+
+    songs that get loaded by the infinite scroll aren't sorted yet
+        add some kind of listener on content changes and sort them after they're loaded?
+    */
+
+    /* sorting https://music.apple.com/library/songs does not work since stuff gets loaded (and requested) on scroll */
+    let url = window.location.href;
+
+    /* check for https://music.apple.com/library/playlist/ (and the beta variant + language code) */
+    let matcher = url.match(/(https:\/\/)(beta\.)?(music\.apple.com\/library\/playlist\/)(p\..{15})(\?l.{3})?/);
+
+    let contentNode;
+
+    let songs = new Map();
+
+    /* check if playlist id is set */
+    if (matcher && matcher.length === 6 && matcher[4]) {
+        let playlist = matcher[4].toLowerCase();
+
+        contentNode = document.getElementsByClassName('songs-list')[0];
+
+        if (contentNode) {
+            /* click does not register if we add the event listener to the child divs themselves */
+            contentNode.addEventListener('click', event => {
+                /* last check of playlist id */
+                if (!playlist) {
+                    return;
+                }
+
+                storeSongs(playlist);
+
+                if (checkClickArea('songs-list__header-col--song', event)) {
+                    console.log('clicked song column');
+                } else if (checkClickArea('songs-list__header-col--artist', event)) {
+                    sortByArtist();
+                } else if (checkClickArea('songs-list__header-col--album', event)) {
+                    sortByAlbum();
+                } else if (checkClickArea('songs-list__header-col--time', event)) {
+                    console.log('clicked time column');
+                }
+            });
+        }
+    }
+
+    function storeSongs(playlist) {
+        /* get the cached data */
+        let storageData = MusicKit.getInstance().api.storage.data;
+
+        for (let element in storageData) {
+            if (storageData.hasOwnProperty(element)) {
+                /* check for the stored playlist data */
+                if (element.match('(.*?)(library\.playlists\.)(' + playlist + ')(\..*)')) {
+                    let value = JSON.parse(storageData[element]);
+
+                    console.log('object', value);
+
+                    let objects = value.d;
+
+                    for (let object of objects) {
+                        if (object.id.startsWith('p')) {
+                            /* playlist */
+                            let songData = object.relationships.tracks.data;
+
+                            for (let song of songData) {
+                                songs.set(song.id, {data: song, node: null});
+                            }
+                        } else {
+                            /* song */
+                            songs.set(object.id, {data: object, node: null});
+                        }
+                    }
+
+                    /*
+                    can be relevant for sorting:
+                        song.attributes:
+                            artistname
+                            albumname
+                            discnumber
+                            name
+                            tracknumber
+                     */
+                }
+            }
+        }
+
+        let songNodes = contentNode.getElementsByClassName('songs-list-row');
+
+        let songNodeData = [];
+
+        /* store the node data and some other stuff to compare with the already stored songs */
+        for (let songNode of songNodes) {
+            let data = {
+                songName: '',
+                artistName: '',
+                albumName: '',
+                time: '',
+                node: songNode
+            };
+
+            data.songName = songNode.getElementsByClassName('songs-list-row__song-name')[0].innerText;
+            data.artistName = songNode.getElementsByClassName('songs-list-row__link')[0].innerText;
+            data.albumName = songNode.getElementsByClassName('songs-list__col--album')[0].getElementsByTagName('p')[0].innerText;
+            data.time = songNode.getElementsByClassName('songs-list-row__length')[0].innerText;
+
+            songNodeData.push(data);
+        }
+
+        /* add the node elements to the song data */
+        for (let song of songs.values()) {
+            for (data of songNodeData) {
+                if (data.songName === song.data.attributes.name && data.albumName === song.data.attributes.albumName) {
+                    song.node = data.node;
+                }
+            }
+        }
+
+        console.log('stored songs', songs);
+    }
+
+    function sortByArtist() {
+        songs = new Map([...songs.entries()].sort((a, b) => {
+            let valueA = a[1];
+            let valueB = b[1];
+
+            /* can add aditional sorting, like track number etc. */
+            return valueA.data.attributes.artistName.localeCompare(valueB.data.attributes.artistName);
+        }));
+
+        manageNodes();
+    }
+
+    function sortByAlbum() {
+        songs = new Map([...songs.entries()].sort((a, b) => {
+            let valueA = a[1];
+            let valueB = b[1];
+
+            /* can add aditional sorting, like track number etc. */
+            return valueA.data.attributes.albumName.localeCompare(valueB.data.attributes.albumName);
+        }));
+
+        manageNodes();
+    }
+
+    function manageNodes() {
+        let headerNode = contentNode.getElementsByClassName('songs-list__header')[0];
+        let weirdNode = contentNode.getElementsByClassName('songs-list__right-click-target')[0];
+        let infiniteScrollNode = contentNode.getElementsByClassName('infinite-scroll')[0];
+
+        while (contentNode.firstChild) {
+            contentNode.firstChild.remove();
+        }
+
+        contentNode.appendChild(headerNode);
+        contentNode.appendChild(weirdNode);
+
+        for (let song of songs.values()) {
+            /* can be 'null' if the cached elements have not been loaded in the document yet */
+            if (song.node) {
+                contentNode.appendChild(song.node);
+            }
+        }
+
+        contentNode.appendChild(infiniteScrollNode);
+    }
+
+    function checkClickArea(className, event) {
+        let column = contentNode.getElementsByClassName(className)[0];
+
+        let artistRectangle = column.getBoundingClientRect();
+
+        /* don't need to check height since its the same for the entire row */
+        if (event.clientX >= artistRectangle.left && event.clientX <= artistRectangle.right) {
+            console.log('column', column);
+
+            return true;
+        }
+
+        return false;
+    }
+} catch (e) {
+    console.error("[JS] Error while trying to apply addSort.js", e);
+}


### PR DESCRIPTION
# Sorting Playlists

## Getting the data

At the start we get the playlist ID of the currently loaded page
This also makes sure that we actually do something - no playlist ID means nothing to do

Once we know we are in a playlist page we go through the document and get all nodes
For each node we create a unique ID by combining the following elements:
- song name
- artist name
- album name

After that we can access the cache for MusicKit to get the data that was requested
(Which means we won't have to call the API as well)

We go through each cached song and assign a node to it
We also store the original index, in case we want to return to the original sorting

## Duplicates
For both the node elements and the cached song data we retain a count on how many instances (duplicates) of that element exist
We do that by having a map with the either the song ID or the combined ID of the node element as the key

Once we notice that the maps for the nodes or the songs aleady have the ID as an entry we interact with this duplicate map

## Sorting
Once we click on a header cell (like album, artists, ...) we save the corresponding attribute name of the song element, which we can use to sort

If we sort by artists that would be `artistName`, if we sort by time it would be `durationInMillis`
This allows us to have a single function which handles sorting by simply accessing these attributes like this:
`songElement.data.attributes[sortConfig.attributeName]`

## Newly loaded items (infinite scroll)
Once we scroll to the end of the page new elements (nodes) get loaded
(And new request might get sent - if they're not already cached - that is why we process the cache again)
We handle these by appending an observer to the 'content node', to which these new nodes get appened to

In this observer we check for `DIV` nodes and add them to our `songNodes` map
After that we go through our `song` map to check if any of them are still missing their `node` elements
Once we have done all that we can sort again

## Sorting the queue
Once the user double clicks a row, or clicks the play icon the queue will get loaded with all songs after the one you clicked on
In reality all songs of the playlist are in the queue but by using a `position` variable these elements get skipped
Since we cannot rely on this variable if we want to sort the queue, we will have to remove all elements we do not need

The safest way to do that is to simply create a new queue and set it

We start by sorting the current queue list with our `sortConfig.attributeName` and `sortConfig.order`
After that we get the currently playing song - with our sorted list and this current song element (index) we can simply use the `splice()` function - this way we are only left with the songs we need

We then set the queue with our sorted list
As of now there is a timeout required to reliably start the playback

# Change to load.js
I had to add the `;0` part because Electron seems to clone something in my code which it does not like = causing an error

Since the return (cloned values) do not get used anyway, this doesn't seem to be a loss